### PR TITLE
change freetype dependency url and hash to match freetype used in SDL_ttf

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
             .hash = "1220b8588f106c996af10249bfa092c6fb2f35fbacb1505ef477a0b04a7dd1063122",
         },
         .freetype = .{
-            .url = "git+https://github.com/allyourcodebase/freetype.git#d0a748192f26bd20f9f339d0d7156b84e90eb4dc",
-            .hash = "1220fb290c4071d0d889d27762282f473b5f9cb9a7e2b429bcb9acbd9172a6e2a1e4",
+            .url = "git+https://github.com/allyourcodebase/freetype#d0a748192f26bd20f9f339d0d7156b84e90eb4dc",
+            .hash = "freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms",
         },
     },
 }


### PR DESCRIPTION
I suddenly got this error in some ci builds when building a project with the [SDL_ttf](https://github.com/allyourcodebase/SDL_ttf) dependency:
``` bash
/root/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: error: file exists in multiple modules
/root/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: note: root of module root.@dependencies.freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms
/root/.cache/zig/p/freetype-2.13.2-AAAAAByJAAD7KQxAcdDYidJ3YigvRztfnLmn4rQpvLms/build.zig:1:1: note: root of module root.@dependencies.1220fb290c4071d0d889d27762282f473b5f9cb9a7e2b429bcb9acbd9172a6e2a1e4
```
I could not reproduce this on my local machine for some reason but this change fixed it. 

I don't really know if this is how this problem should be fixed but i thought i'd share this as a pull request anyway.
I guess the harfbuzz dependency in the [SDL_ttf](https://github.com/allyourcodebase/SDL_ttf) repo needs to be updated accordingly if this is merged.